### PR TITLE
Ensure proper removal of codemirror instance on vue destroy

### DIFF
--- a/codemirror.vue
+++ b/codemirror.vue
@@ -188,7 +188,10 @@ export default {
     if (!window.JSHINT) window.JSHINT = require('jshint').JSHINT
   },
 
-  beforeDestroy () { window.JSHINT = null },
+  beforeDestroy () { 
+    window.JSHINT = null
+    this.editor.getWrapperElement().remove()
+  },
 
   watch: {
     code (newVal, oldVal) {


### PR DESCRIPTION
This allows this vue wrapper to be used eg under the v-if directive